### PR TITLE
Make Django 1.9 compatible #ALTOS-9048

### DIFF
--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytz
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.db import models
 from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
@@ -227,7 +227,7 @@ class CalendarRelation(models.Model):
     calendar = models.ForeignKey(Calendar, verbose_name=_("calendar"))
     content_type = models.ForeignKey(ContentType)
     object_id = models.IntegerField()
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20, null=True)
     inheritable = models.BooleanField(_("inheritable"), default=True)
 

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -3,7 +3,7 @@ from django.conf import settings as django_settings
 import pytz
 from dateutil import rrule
 
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.db import models
 from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
@@ -420,7 +420,7 @@ class EventRelation(models.Model):
     event = models.ForeignKey(Event, verbose_name=_("event"))
     content_type = models.ForeignKey(ContentType)
     object_id = models.IntegerField()
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20, null=True)
 
     objects = EventRelationManager()


### PR DESCRIPTION
Makes django-scheduler compatible with Django 1.7, 1.8 and 1.9
