### PR TITLE
Calendar update time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+INSTALL_INSTALL_DIR ?= /usr/local/altschool/django-scheduler
+
+# Helpers
+PIP = $(INSTALL_DIR)/bin/pip
+PYTHON = $(INSTALL_DIR)/bin/python
+MANAGE_PY = $(PYTHON) manage.py
+SETUP_PY = $(PYTHON) setup.py
+
+.PHONY: clean install test
+
+define header
+  @tput setaf 6
+  @echo "==> $1"
+  @tput sgr0
+endef
+
+$(INSTALL_DIR): $(INSTALL_DIR)/bin/activate
+	mkdir -p $(INSTALL_DIR)/www/static
+
+$(INSTALL_DIR)/bin/activate: setup.py
+	$(call header,"Installing")
+	@test -d $(INSTALL_DIR) || virtualenv $(INSTALL_DIR)
+	@$(PIP) install -q --upgrade pip==8.0.0
+	@touch $(INSTALL_DIR)/bin/activate
+
+install: $(INSTALL_DIR)
+	$(call header,"Building")
+	@$(SETUP_PY) -q install
+
+test: install
+	$(call header,"Running unit tests")
+	@$(SETUP_PY) test
+
+# Create new migrations
+migrations: $(INSTALL_DIR)
+	$(call header,"Creating migrations")
+	@$(MANAGE_PY) makemigrations
+
+uninstall:
+	$(call header,"Uninstalling")
+	@rm -rf $(INSTALL_DIR)
+
+clean: uninstall
+	$(call header,"Cleaning")
+	@rm -rf django_scheduler.egg-info

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/schedule/migrations/0003_calendar_last_update_time.py
+++ b/schedule/migrations/0003_calendar_last_update_time.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('schedule', '0002_event_recent_start'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='calendar',
+            name='last_update_time',
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+            preserve_default=True,
+        ),
+    ]

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from django.template.defaultfilters import slugify
 import datetime
@@ -136,6 +137,10 @@ class Calendar(models.Model):
 
     name = models.CharField(_("name"), max_length=200)
     slug = models.SlugField(_("slug"), max_length=200)
+    last_update_time = models.DateTimeField(
+        default=timezone.now,
+        editable=False
+    )
     objects = CalendarManager()
 
     class Meta:
@@ -180,6 +185,11 @@ class Calendar(models.Model):
 
     def add_event_url(self):
         return reverse('calendar_create_event', args=[self.slug])
+
+    def save(self, *args, **kwargs):
+        if self.id:
+            self.last_update_time = timezone.now()
+        return super(Calendar, self).save(*args, **kwargs)
 
 
 class CalendarRelationManager(models.Manager):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                  'Topic :: Utilities'],
     install_requires=[
         'python-dateutil>=2.1.post20140303',
-        'Django>=1.7',
+        'django==1.7',
         'argparse==1.1',
         'pytz>=2013.9',
         'six>=1.3.0',

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -130,3 +130,20 @@ class TestCalendar(TestCase):
         calendar.add_event_url()
         relation = CalendarRelation.objects.create_relation(calendar, rule)
         relation.__unicode__()
+
+    def test_last_update_time(self):
+        calendar = Calendar.objects.create(name='My Cal')
+        self.assertIsNotNone(calendar.last_update_time)
+
+        calendar.name = 'New name'
+        previous_update_time = calendar.last_update_time
+        calendar.save()
+        self.assertNotEqual(previous_update_time, calendar.last_update_time)
+
+        # Make sure calendar update time changed with new event.
+        start_after = timezone.now() + datetime.timedelta(days=1)
+        end_after = start_after + datetime.timedelta(hours=1)
+        event = self.__create_event(start_after, end_after)
+        previous_update_time = calendar.last_update_time
+        calendar.events.add(event)
+        self.assertNotEqual(previous_update_time, calendar.last_update_time)


### PR DESCRIPTION
- Update development workflow
- Fix dependencies issue
- Add `Calendar.last_update_time` field to track calendar updates (each event update will be reflected on calendar update time). This is useful for Sensor Sea in order to know whether it needs to regenerate Celery schedules

NOTE: `test_edge_case_events` and `test_event_get_occurrences_after` are failing. I guess we need to create a ticket for this.
