### PR TITLE
Use `GET` or `POST` instead of `REQUEST`

### DIFF
--- a/schedule/forms.py
+++ b/schedule/forms.py
@@ -4,9 +4,9 @@ from schedule.models import Event, Occurrence
 
 
 class SpanForm(forms.ModelForm):
-    start = forms.DateTimeField(label=_("start"),
+    start = forms.SplitDateTimeField(label=_("start"),
                                 widget=forms.SplitDateTimeWidget)
-    end = forms.DateTimeField(label=_("end"),
+    end = forms.SplitDateTimeField(label=_("end"),
                               widget=forms.SplitDateTimeWidget,
                               help_text=_(u"The end time must be later than start time."))
 

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -323,8 +323,9 @@ def get_next_url(request, default):
     next = default
     if OCCURRENCE_CANCEL_REDIRECT:
         next = OCCURRENCE_CANCEL_REDIRECT
-    if 'next' in request.REQUEST and check_next_url(request.REQUEST['next']) is not None:
-        next = request.REQUEST['next']
+    request_next = request.GET.get('next', None) or request.POST.get('next', None)
+    if request_next is not None and check_next_url(request_next) is not None:
+        next = request_next
     return next
 
 


### PR DESCRIPTION
Also fix the datetime fields

Turns out `SplitDateTimeWidget` only works with `SplitDateTimeField`, so any changes to `start` or `end` were being considered invalid.