### PR TITLE
Update version to match git tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='django-scheduler',
-    version='10.7.7',
+    version='10.7.15',
     description='A calendaring app for Django.',
     author='Leonardo Lazzaro',
     author_email='lazzaroleonardo@gmail.com',


### PR DESCRIPTION
We're installing this repo from `models` requesting v10.7.9 but pip warns us that it can only install v10.7.7. I was looking for some conflicting dependency, but it turns out it's just the version number in `setup.py`

I updated it to have the version of the latest tag, but if we don't want to rewrite the tag, we may want to update the version to the next version, meaning v10.7.16. Thoughts?