### PR TITLE
update min and max django version in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
                  'Topic :: Utilities'],
     install_requires=[
         'python-dateutil>=2.1.post20140303',
-        'Django>=1.7,<=1.11',
+        'Django>=1.8,<=2.0',
         'argparse>=1.1',
         'pytz>=2013.9',
         'six>=1.3.0',


### PR DESCRIPTION
Update max django version so that we can use this lib with version 1.11.x
Update min django version because we no longer want to support 1.7 now that we support 1.11