### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-django-scheduler
+(Deprecated) django-scheduler
 ================


### PR DESCRIPTION
All the projects this repo is pulled into are deprecated afaict: https://github.com/AltSchool/django-scheduler/pull/new/deprecation-notice

Once this is merged in i'll archive this repo